### PR TITLE
Remove tagline, COSCUP news item, and audio-to-audio mention

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,11 +282,9 @@
       <span style="--i:0;--h:30"></span><span style="--i:1;--h:55"></span><span style="--i:2;--h:80"></span><span style="--i:3;--h:45"></span><span style="--i:4;--h:95"></span><span style="--i:5;--h:60"></span><span style="--i:6;--h:35"></span><span style="--i:7;--h:75"></span><span style="--i:8;--h:100"></span><span style="--i:9;--h:50"></span><span style="--i:10;--h:70"></span><span style="--i:11;--h:40"></span><span style="--i:12;--h:85"></span><span style="--i:13;--h:55"></span><span style="--i:14;--h:30"></span><span style="--i:15;--h:65"></span><span style="--i:16;--h:90"></span><span style="--i:17;--h:45"></span><span style="--i:18;--h:60"></span><span style="--i:19;--h:35"></span>
     </div>
 
-    <p class="tagline">Teaching language models to <em>listen and speak</em> — not just read and write.</p>
-
     <p class="intro">
       I'm a Research Scientist at <strong>Google DeepMind</strong>, working on audio-native
-      large language models: audio-to-audio architectures, post-training, and making
+      large language models: post-training and making
       speech generation controllable. I also build open models for Traditional Chinese —
       I created <a href="https://huggingface.co/collections/yentinglin/taiwan-llm-6523f5a2d6ca498dc3810f07" target="_blank" rel="noopener">Taiwan-LLM</a> and Llama-3-Taiwan.
     </p>
@@ -306,7 +304,6 @@
   <section id="news">
     <h2>News</h2>
     <ul class="news">
-      <li><time>2026</time><span>Invited <strong>Prime Session speaker</strong> at COSCUP 2026, Taipei.</span></li>
       <li><time>2025</time><span>Released <em>Step-KTO</em>, stepwise binary feedback for mathematical reasoning.</span></li>
       <li><time>2024</time><span><em>Measuring Taiwanese Mandarin Language Understanding</em> accepted to COLM 2024.</span></li>
       <li><time>2024</time><span>Released <strong>Llama-3-Taiwan</strong>, open-weight Traditional Chinese LLMs.</span></li>


### PR DESCRIPTION
## Summary

Three content removals requested by the user:

1. The hero tagline ("Teaching language models to *listen and speak* — not just read and write.")
2. "audio-to-audio architectures," from the intro — the sentence now reads "…audio-native large language models: post-training and making speech generation controllable." (dropped the serial comma since only two items remain)
3. The COSCUP 2026 Prime Session news item

The unused `.tagline` CSS rule was left in place in case a tagline returns later. Verified with a local build and screenshot — hero spacing reads cleanly without the tagline.

https://claude.ai/code/session_0121uHjXorNk6tByfZmGcmUu

---
_Generated by [Claude Code](https://claude.ai/code/session_0121uHjXorNk6tByfZmGcmUu)_