### PR TITLE
Fix Chinese name font: use Noto Serif TC

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Noto+Serif+TC:wght@500&text=%E6%9E%97%E5%BD%A5%E5%BB%B7&display=swap" rel="stylesheet">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-JK5PXDXS4M"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -94,7 +95,8 @@
   }
 
   .name .zh {
-    font-weight: 400;
+    font-family: 'Noto Serif TC', 'PingFang TC', 'Microsoft JhengHei', serif;
+    font-weight: 500;
     color: var(--ink-faint);
     font-size: 0.5em;
     margin-left: .4em;


### PR DESCRIPTION
## Summary

Fixes the Chinese name (林彥廷) rendering in the hero. Newsreader — the serif used for the name — has no CJK glyphs, so the characters fell back to the browser's default font and looked mismatched next to the Latin serif.

### Fix
- Load **Noto Serif TC** (weight 500) from Google Fonts, subset to just the three characters via the `text=` parameter, so the font payload is tiny
- Give `.name .zh` a Traditional Chinese serif stack: `'Noto Serif TC', 'PingFang TC', 'Microsoft JhengHei', serif`

### Verification
Confirmed in headless Chromium that the subset woff2 is fetched and `document.fonts.check('20px "Noto Serif TC"', '林彥廷')` returns true; the rendered name now shows proper Ming-style serif forms matching the Newsreader Latin.

https://claude.ai/code/session_0121uHjXorNk6tByfZmGcmUu

---
_Generated by [Claude Code](https://claude.ai/code/session_0121uHjXorNk6tByfZmGcmUu)_